### PR TITLE
ci: add GitHub Actions workflows and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,18 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - development
+      - main
+  pull_request:
+    branches:
+      - development
+      - main
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Screenly/edge-apps-actions/checks@v1

--- a/.github/workflows/initialize-edge-app.yml
+++ b/.github/workflows/initialize-edge-app.yml
@@ -1,0 +1,40 @@
+---
+name: Initialize Edge App
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment for initialization
+        required: true
+        default: stage
+        type: choice
+        options:
+          - stage
+          - production
+      edge_app_name:
+        description: Edge App name (used for the CLI --name flag)
+        required: true
+        type: string
+      edge_app_title:
+        description: Display title for the Edge App instance
+        required: true
+        type: string
+
+run-name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
+
+jobs:
+  initialize:
+    name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.environment == 'production' && 'main' || github.ref }}
+      - uses: Screenly/edge-apps-actions/initialize@v1
+        with:
+          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
+          edge_app_name: ${{ inputs.edge_app_name }}
+          edge_app_title: ${{ inputs.edge_app_title }}
+          environment: ${{ inputs.environment }}

--- a/.github/workflows/update-edge-app.yml
+++ b/.github/workflows/update-edge-app.yml
@@ -1,0 +1,38 @@
+---
+name: Update Edge App
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - development
+      - main
+
+run-name: Updating Weather App in ${{ github.event_name == 'workflow_dispatch' && 'stage' || (github.ref == 'refs/heads/main' && 'production' || 'stage') }}
+
+jobs:
+  deploy-stage:
+    name: Updating Weather App in stage
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/development') || github.event_name == 'workflow_dispatch'
+    environment: stage
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Screenly/edge-apps-actions/update@v1
+        with:
+          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
+          environment: stage
+          delete_missing_settings: 'true'
+
+  deploy-production:
+    name: Updating Weather App in production
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: production
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Screenly/edge-apps-actions/update@v1
+        with:
+          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
+          environment: production
+          delete_missing_settings: 'true'


### PR DESCRIPTION
## Summary

- Add checks workflow for linting and validation on PRs and pushes
- Add initialize-edge-app workflow for manual Edge App provisioning
- Add update-edge-app workflow for deploying to stage and production
- Add Dependabot config for monthly npm dependency updates